### PR TITLE
Adding a casesensitive flag to manage the sql generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 **/.env.local
 **/.dockerhub.env
 **/.ghcr.env
+.claude/settings.local.json
 
 # Next.js build output
 packages/app/.next

--- a/packages/common-utils/src/__tests__/queryParser.test.ts
+++ b/packages/common-utils/src/__tests__/queryParser.test.ts
@@ -439,4 +439,189 @@ describe('CustomSchemaSQLSerializerV2 - json', () => {
       propertyType: 'json',
     });
   });
+
+  describe('caseSensitive', () => {
+    const mockMetadata = getMetadata(new ClickhouseClient({ host: '' }));
+    // @ts-ignore
+    mockMetadata.getColumn = ({ column }) => {
+      return new Promise(resolve => {
+        if (column.indexOf('.') >= 0) return resolve(undefined);
+        if (column === 'Body') {
+          return resolve({
+            name: 'Body',
+            type: 'String',
+            codec_expression: '',
+            comment: '',
+            default_expression: '',
+            default_type: '',
+            ttl_expression: '',
+          });
+        }
+        const testTable = getTestTable(column);
+        // @ts-ignore
+        return resolve(testTable);
+      });
+    };
+
+    const caseSensitiveSerializer = new CustomSchemaSQLSerializerV2({
+      metadata: mockMetadata,
+      databaseName,
+      tableName,
+      connectionId,
+      implicitColumnExpression: 'Body',
+      caseSensitive: true,
+    });
+
+    const caseInsensitiveSerializer = new CustomSchemaSQLSerializerV2({
+      metadata: mockMetadata,
+      databaseName,
+      tableName,
+      connectionId,
+      implicitColumnExpression: 'Body',
+      caseSensitive: false,
+    });
+
+    it('implicit field - single token uses hasToken when caseSensitive', async () => {
+      const result = await caseSensitiveSerializer.fieldSearch(
+        '<implicit>',
+        'error',
+        false,
+        false,
+        false,
+      );
+      expect(result).toBe("(hasToken(Body, 'error'))");
+    });
+
+    it('implicit field - single token uses hasTokenCaseInsensitive when not caseSensitive', async () => {
+      const result = await caseInsensitiveSerializer.fieldSearch(
+        '<implicit>',
+        'error',
+        false,
+        false,
+        false,
+      );
+      expect(result).toBe("(hasTokenCaseInsensitive(Body, 'error'))");
+    });
+
+    it('implicit field - wildcard uses LIKE without lower() when caseSensitive', async () => {
+      const result = await caseSensitiveSerializer.fieldSearch(
+        '<implicit>',
+        'err',
+        false,
+        false,
+        true,
+      );
+      expect(result).toBe("(Body LIKE 'err%')");
+    });
+
+    it('implicit field - wildcard uses lower() LIKE lower() when not caseSensitive', async () => {
+      const result = await caseInsensitiveSerializer.fieldSearch(
+        '<implicit>',
+        'err',
+        false,
+        false,
+        true,
+      );
+      expect(result).toBe("(lower(Body) LIKE lower('err%'))");
+    });
+
+    it('implicit field - tokens with separators uses hasToken when caseSensitive', async () => {
+      const result = await caseSensitiveSerializer.fieldSearch(
+        '<implicit>',
+        'hello world',
+        false,
+        false,
+        false,
+      );
+      expect(result).toContain("hasToken(Body, 'hello')");
+      expect(result).toContain("hasToken(Body, 'world')");
+      expect(result).toContain("(Body LIKE '%hello world%')");
+      expect(result).not.toContain('hasTokenCaseInsensitive');
+      expect(result).not.toContain('lower');
+    });
+
+    it('implicit field - tokens with separators uses hasTokenCaseInsensitive when not caseSensitive', async () => {
+      const result = await caseInsensitiveSerializer.fieldSearch(
+        '<implicit>',
+        'hello world',
+        false,
+        false,
+        false,
+      );
+      expect(result).toContain("hasTokenCaseInsensitive(Body, 'hello')");
+      expect(result).toContain("hasTokenCaseInsensitive(Body, 'world')");
+      expect(result).toContain("(lower(Body) LIKE lower('%hello world%'))");
+      expect(result).not.toContain('hasToken(');
+    });
+
+    it('JSON field uses LIKE when caseSensitive', async () => {
+      const result = await caseSensitiveSerializer.fieldSearch(
+        'serviceName',
+        'myService',
+        false,
+        false,
+        false,
+      );
+      expect(result).toBe(
+        "(toString(`serviceName`) LIKE '%myService%')",
+      );
+    });
+
+    it('JSON field uses ILIKE when not caseSensitive', async () => {
+      const result = await caseInsensitiveSerializer.fieldSearch(
+        'serviceName',
+        'myService',
+        false,
+        false,
+        false,
+      );
+      expect(result).toBe(
+        "(toString(`serviceName`) ILIKE '%myService%')",
+      );
+    });
+
+    it('non-implicit String field uses LIKE when caseSensitive', async () => {
+      const result = await caseSensitiveSerializer.fieldSearch(
+        'Body',
+        'myTerm',
+        false,
+        false,
+        false,
+      );
+      expect(result).toBe("(Body LIKE '%myTerm%')");
+    });
+
+    it('non-implicit String field uses ILIKE when not caseSensitive', async () => {
+      const result = await caseInsensitiveSerializer.fieldSearch(
+        'Body',
+        'myTerm',
+        false,
+        false,
+        false,
+      );
+      expect(result).toBe("(Body ILIKE '%myTerm%')");
+    });
+
+    it('negated implicit field - single token uses NOT hasToken when caseSensitive', async () => {
+      const result = await caseSensitiveSerializer.fieldSearch(
+        '<implicit>',
+        'error',
+        true,
+        false,
+        false,
+      );
+      expect(result).toBe("(NOT hasToken(Body, 'error'))");
+    });
+
+    it('negated implicit field - wildcard uses NOT LIKE without lower() when caseSensitive', async () => {
+      const result = await caseSensitiveSerializer.fieldSearch(
+        '<implicit>',
+        'err',
+        true,
+        true,
+        true,
+      );
+      expect(result).toBe("(Body NOT LIKE '%err%')");
+    });
+  });
 });

--- a/packages/common-utils/src/queryParser.ts
+++ b/packages/common-utils/src/queryParser.ts
@@ -179,6 +179,7 @@ class EnglishSerializer implements Serializer {
 
 export abstract class SQLSerializer implements Serializer {
   private NOT_FOUND_QUERY = '(1 = 0)';
+  protected caseSensitive = false;
 
   abstract getColumnForField(field: string): Promise<{
     column?: string;
@@ -346,7 +347,7 @@ export abstract class SQLSerializer implements Serializer {
       );
     } else if (propertyType === JSDataType.JSON) {
       return SqlString.format(
-        `(${columnJSON?.string} ${isNegatedField ? 'NOT ' : ''}ILIKE ?)`,
+        `(${columnJSON?.string} ${isNegatedField ? 'NOT ' : ''}${this.caseSensitive ? 'LIKE' : 'ILIKE'} ?)`,
         [`%${term}%`],
       );
     }
@@ -362,7 +363,9 @@ export abstract class SQLSerializer implements Serializer {
       // to utilize the token bloom filter unless a prefix/sufix wildcard is specified
       if (prefixWildcard || suffixWildcard) {
         return SqlString.format(
-          `(lower(?) ${isNegatedField ? 'NOT ' : ''}LIKE lower(?))`,
+          this.caseSensitive
+            ? `(? ${isNegatedField ? 'NOT ' : ''}LIKE ?)`
+            : `(lower(?) ${isNegatedField ? 'NOT ' : ''}LIKE lower(?))`,
           [
             SqlString.raw(column ?? ''),
             `${prefixWildcard ? '%' : ''}${term}${suffixWildcard ? '%' : ''}`,
@@ -371,24 +374,27 @@ export abstract class SQLSerializer implements Serializer {
       } else {
         // We can't search multiple tokens with `hasToken`, so we need to split up the term into tokens
         const hasSeperators = this.termHasSeperators(term);
+        const hasTokenFn = this.caseSensitive
+          ? 'hasToken'
+          : 'hasTokenCaseInsensitive';
         if (hasSeperators) {
           const tokens = this.tokenizeTerm(term);
           return `(${isNegatedField ? 'NOT (' : ''}${[
             ...tokens.map(token =>
-              SqlString.format(`hasTokenCaseInsensitive(?, ?)`, [
+              SqlString.format(`${hasTokenFn}(?, ?)`, [
                 SqlString.raw(column ?? ''),
                 token,
               ]),
             ),
             // If there are symbols in the term, we'll try to match the whole term as well (ex. Scott!)
-            SqlString.format(`(lower(?) LIKE lower(?))`, [
-              SqlString.raw(column ?? ''),
-              `%${term}%`,
-            ]),
+            SqlString.format(
+              this.caseSensitive ? `(? LIKE ?)` : `(lower(?) LIKE lower(?))`,
+              [SqlString.raw(column ?? ''), `%${term}%`],
+            ),
           ].join(' AND ')}${isNegatedField ? ')' : ''})`;
         } else {
           return SqlString.format(
-            `(${isNegatedField ? 'NOT ' : ''}hasTokenCaseInsensitive(?, ?))`,
+            `(${isNegatedField ? 'NOT ' : ''}${hasTokenFn}(?, ?))`,
             [SqlString.raw(column ?? ''), term],
           );
         }
@@ -397,7 +403,12 @@ export abstract class SQLSerializer implements Serializer {
       const shoudUseTokenBf = isImplicitField;
       return SqlString.format(
         `(${column} ${isNegatedField ? 'NOT ' : ''}? ?)`,
-        [SqlString.raw(shoudUseTokenBf ? 'LIKE' : 'ILIKE'), `%${term}%`],
+        [
+          SqlString.raw(
+            shoudUseTokenBf || this.caseSensitive ? 'LIKE' : 'ILIKE',
+          ),
+          `%${term}%`,
+        ],
       );
     }
   }
@@ -426,6 +437,7 @@ export type CustomSchemaConfig = {
   columnAliases?: Record<string, string>;
   tableName: string;
   connectionId: string;
+  caseSensitive?: boolean;
 };
 
 export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
@@ -445,6 +457,7 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
     implicitColumnExpression,
     fallbackAttributeExpression,
     columnAliases,
+    caseSensitive,
   }: { metadata: Metadata } & CustomSchemaConfig) {
     super();
     this.metadata = metadata;
@@ -454,6 +467,7 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
     this.fallbackAttributeExpression = fallbackAttributeExpression;
     this.columnAliases = columnAliases ?? {};
     this.connectionId = connectionId;
+    this.caseSensitive = caseSensitive ?? false;
   }
 
   /**

--- a/packages/common-utils/src/renderChartConfig.ts
+++ b/packages/common-utils/src/renderChartConfig.ts
@@ -367,6 +367,7 @@ async function renderSelectList(
         columnAliases: chartConfig.columnAliases,
         metadata,
         connectionId: chartConfig.connection,
+        caseSensitive: chartConfig.caseSensitive,
         with: chartConfig.with,
       });
 
@@ -579,6 +580,7 @@ async function renderWhereExpression({
   fallbackAttributeExpression,
   columnAliases,
   connectionId,
+  caseSensitive,
   with: withClauses,
 }: {
   condition: SearchCondition;
@@ -589,6 +591,7 @@ async function renderWhereExpression({
   fallbackAttributeExpression?: string;
   columnAliases?: Record<string, string>;
   connectionId: string;
+  caseSensitive?: boolean;
   with?: ChartConfigWithDateRange['with'];
 }): Promise<ChSql> {
   let _condition = condition;
@@ -601,6 +604,7 @@ async function renderWhereExpression({
       fallbackAttributeExpression,
       columnAliases,
       connectionId: connectionId,
+      caseSensitive,
     });
     const builder = new SearchQueryBuilder(condition, serializer);
     _condition = await builder.build();
@@ -646,6 +650,7 @@ async function renderWhere(
         columnAliases: chartConfig.columnAliases,
         metadata,
         connectionId: chartConfig.connection,
+        caseSensitive: chartConfig.caseSensitive,
         with: chartConfig.with,
       }),
       '(',
@@ -674,6 +679,7 @@ async function renderWhere(
               columnAliases: chartConfig.columnAliases,
               metadata,
               connectionId: chartConfig.connection,
+              caseSensitive: chartConfig.caseSensitive,
               with: chartConfig.with,
             });
           }
@@ -703,6 +709,7 @@ async function renderWhere(
             columnAliases: chartConfig.columnAliases,
             metadata,
             connectionId: chartConfig.connection,
+            caseSensitive: chartConfig.caseSensitive,
             with: chartConfig.with,
           }),
           '(',

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -367,6 +367,7 @@ export const _ChartConfigSchema = z.object({
   selectGroupBy: z.boolean().optional(),
   metricTables: MetricTableSchema.optional(),
   seriesReturnType: z.enum(['ratio', 'column']).optional(),
+  caseSensitive: z.boolean().optional(),
 });
 
 // This is a ChartConfig type without the `with` CTE clause included.


### PR DESCRIPTION
In order to use the new fulltext search index we need to use `hasToken` instead of `hasTokenCaseInsensitive`. This PR adds a parameter so that we can pass in a flag to the chart specification that lets us indicate that the query should be case sensitive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core query-to-SQL translation used by charts; incorrect toggling could alter result sets or query performance (index usage) across multiple query paths, though behavior defaults to existing case-insensitive mode.
> 
> **Overview**
> Adds a new optional `caseSensitive` flag to `ChartConfig` and threads it through chart SQL generation so lucene `where`/filters/aggConditions can emit case-sensitive ClickHouse predicates.
> 
> Updates `SQLSerializer`/`CustomSchemaSQLSerializerV2` to switch between `hasToken` vs `hasTokenCaseInsensitive` and `LIKE` vs `ILIKE`/`lower(...)` based on the flag (including JSON string searches and wildcard/negated implicit searches), with new unit tests covering the generated SQL. Also ignores `.claude/settings.local.json` in `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 715a5ee22e015931687dc9635d1f3bb689be39d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->